### PR TITLE
sc-17999 - Remove stop propagation on mouse up event when resizing table columns

### DIFF
--- a/lib/helpers/resizeable-columns.js
+++ b/lib/helpers/resizeable-columns.js
@@ -67,14 +67,13 @@ module.exports = function (table, hasChildRow, isChildRowTogglerFirst, resizeabl
         document.addEventListener("mouseup", function (e) {
             if (e.target.nodeName === 'INPUT') return;
 
-      e.stopPropagation();
-      curCol = undefined;
-      nxtCol = undefined;
-      pageX = undefined;
-      nxtColWidth = undefined;
-      curColWidth = undefined;
-    });
-  }
+            curCol = undefined;
+            nxtCol = undefined;
+            pageX = undefined;
+            nxtColWidth = undefined;
+            curColWidth = undefined;
+        });
+    }
 
     function createDiv(height) {
         var div = document.createElement("div");


### PR DESCRIPTION
https://github.com/matfish2/vue-tables-2/issues/968

https://app.shortcut.com/aquila-learning/story/17999/cannot-select-colour-when-creating-an-assessment